### PR TITLE
Update to Ubuntu 20.04 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # An image with an installation of spt3g
 
 # Use ubuntu base image
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Set the working directory to /app_lib
 WORKDIR /app_lib

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ pulled.txt : check_repo.txt
 
 # Build the docker image
 built.txt : pulled.txt
-	docker pull ubuntu:18.04
+	docker pull ubuntu:20.04
 	docker build -t ${NAME}:$(VERSION) .
 	@echo `date` > built.txt
 


### PR DESCRIPTION
The first in a string of upgrades to get the OCS/SOCS images updated.